### PR TITLE
change the scope of RepositoryFilter::getCollection() to public so you don't have to use an iterator_to_array() to fetch the resultset

### DIFF
--- a/src/Spray/PersistenceBundle/Repository/RepositoryFilter.php
+++ b/src/Spray/PersistenceBundle/Repository/RepositoryFilter.php
@@ -120,7 +120,7 @@ class RepositoryFilter implements RepositoryFilterInterface
      * 
      * @return array
      */
-    private function &getCollection()
+    public function &getCollection()
     {
         if (null === $this->collection) {
             $qb = $this->createAndFilterQueryBuilder($this->getEntityAlias());


### PR DESCRIPTION
First i was thinking of adding this...

``` php
public function toArray()
{
    return iterator_to_array($this);
}
```

but i think changing the scope of the getCollection() would keep things fast with less overhead...
